### PR TITLE
Add Copilot automation workflows

### DIFF
--- a/.github/workflows/auto-apply-copilot-review.yml
+++ b/.github/workflows/auto-apply-copilot-review.yml
@@ -1,0 +1,71 @@
+# Auto-respond to Copilot PR reviews
+#
+# When Copilot PR Reviewer leaves comments, automatically ask the
+# Copilot Coding Agent to apply the suggested changes.
+# Limited to ONCE per PR to avoid burning Copilot minutes.
+
+name: Auto-Apply Copilot Review
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  auto-apply-review:
+    # Only run for Copilot PR Reviewer reviews with comments
+    if: |
+      github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' &&
+      github.event.review.state == 'COMMENTED' &&
+      github.event.pull_request.user.login == 'copilot-swe-agent[bot]'
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Check if already auto-applied once
+        id: check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            // Check for any previous auto-apply comment on this PR
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const hasAutoApplied = comments.data.some(c =>
+              c.body.includes('<!-- auto-apply-copilot-review -->') &&
+              c.user.login === 'github-actions[bot]'
+            );
+
+            if (hasAutoApplied) {
+              console.log('Already auto-applied once on this PR, skipping to save Copilot minutes');
+              core.setOutput('skip', 'true');
+            } else {
+              core.setOutput('skip', 'false');
+            }
+
+      - name: Add comment to apply review suggestions
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const reviewUrl = context.payload.review.html_url;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `@copilot apply the changes based on the review comments in ${reviewUrl}\n\n<!-- auto-apply-copilot-review -->`
+            });
+
+            console.log('Posted auto-apply comment (first and only time for this PR)');

--- a/.github/workflows/auto-approve-workflows.yml
+++ b/.github/workflows/auto-approve-workflows.yml
@@ -1,0 +1,77 @@
+name: Auto-trigger Copilot Workflows
+
+on:
+  schedule:
+    # Run every 15 minutes (reduced from 2 min to save CI minutes)
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: auto-approve-workflows
+  cancel-in-progress: true
+
+jobs:
+  auto-trigger:
+    name: Trigger workflows for blocked Copilot PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger workflows via dispatch (bypasses approval)
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          echo "Checking for action_required workflow runs from Copilot..."
+
+          # Get blocked runs
+          BLOCKED=$(gh api repos/${{ github.repository }}/actions/runs \
+            --jq '[.workflow_runs[] | select(.conclusion == "action_required") | select(.actor.login == "Copilot" or .actor.login == "copilot-swe-agent") | {id: .id, name: .name, branch: .head_branch, workflow_id: .workflow_id}]' \
+            2>/dev/null || echo "[]")
+
+          COUNT=$(echo "$BLOCKED" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No blocked Copilot workflow runs found."
+            exit 0
+          fi
+
+          echo "Found $COUNT blocked runs"
+
+          # Get unique branches with blocked workflows
+          BRANCHES=$(echo "$BLOCKED" | jq -r '[.[].branch] | unique | .[]')
+
+          for BRANCH in $BRANCHES; do
+            echo "Triggering CI for branch: $BRANCH"
+
+            # Check if there's already a REAL running/queued CI for this branch
+            # Exclude action_required (those are blocked and won't run)
+            RUNNING=$(gh api repos/${{ github.repository }}/actions/runs \
+              --jq "[.workflow_runs[] | select(.head_branch == \"$BRANCH\") | select(.status == \"in_progress\" or .status == \"queued\") | select(.conclusion != \"action_required\")] | length" \
+              2>/dev/null || echo "0")
+
+            if [ "$RUNNING" -gt 0 ]; then
+              echo "  Already has $RUNNING running workflows, skipping"
+              continue
+            fi
+
+            # Also check for recently triggered dispatch runs (within last 5 min)
+            RECENT=$(gh api repos/${{ github.repository }}/actions/runs \
+              --jq "[.workflow_runs[] | select(.head_branch == \"$BRANCH\") | select(.event == \"workflow_dispatch\") | select(.conclusion == \"success\" or .status == \"in_progress\" or .status == \"queued\")] | .[0:1] | length" \
+              2>/dev/null || echo "0")
+
+            if [ "$RECENT" -gt 0 ]; then
+              echo "  Recent dispatch run exists, skipping"
+              continue
+            fi
+
+            # Trigger CI via workflow_dispatch (bypasses first-time contributor check)
+            gh api -X POST repos/${{ github.repository }}/actions/workflows/ci.yml/dispatches \
+              -f ref="$BRANCH" 2>&1 || echo "  Failed to trigger CI for $BRANCH"
+
+            # Also trigger CodeQL and Secret Scan
+            gh api -X POST repos/${{ github.repository }}/actions/workflows/codeql.yml/dispatches \
+              -f ref="$BRANCH" 2>&1 || true
+            gh api -X POST repos/${{ github.repository }}/actions/workflows/gitleaks.yml/dispatches \
+              -f ref="$BRANCH" 2>&1 || true
+
+            echo "  Triggered workflows for $BRANCH"
+          done
+
+          echo "Done."

--- a/.github/workflows/copilot-ci-feedback.yml
+++ b/.github/workflows/copilot-ci-feedback.yml
@@ -1,0 +1,161 @@
+name: Copilot CI Feedback
+
+on:
+  workflow_run:
+    workflows: ["CI", "Copilot Branch CI"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  notify-copilot:
+    name: Notify Copilot of CI failures
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          SHORT_SHA="${HEAD_SHA:0:7}"
+
+          echo "head_branch=$HEAD_BRANCH" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+          # Find PR for this branch
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls \
+            --jq ".[] | select(.head.ref == \"$HEAD_BRANCH\" and .state == \"open\") | {number, author: .user.login}" \
+            | head -1)
+
+          if [ -z "$PR_DATA" ]; then
+            echo "No open PR found for branch $HEAD_BRANCH"
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author')
+
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "author=$PR_AUTHOR" >> $GITHUB_OUTPUT
+          echo "found=true" >> $GITHUB_OUTPUT
+
+          # Check if Copilot PR
+          PR_AUTHOR_LOWER=$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+          if [[ "$PR_AUTHOR_LOWER" == *"copilot"* ]] || [[ "$HEAD_BRANCH" == copilot/* ]]; then
+            echo "is_copilot=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_copilot=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check loop protection
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.is_copilot == 'true'
+        id: loop_check
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          SHORT_SHA="${{ steps.pr.outputs.short_sha }}"
+
+          # Get recent comments
+          COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments --jq '.')
+
+          # Count @copilot fix requests in last 2 hours
+          TWO_HOURS_AGO=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          RECENT_FIX_REQUESTS=$(echo "$COMMENTS" | jq --arg since "$TWO_HOURS_AGO" '
+            [.[] | select(
+              (.body | contains("@copilot")) and
+              (.body | ascii_downcase | contains("fix") or contains("failed")) and
+              (.created_at > $since)
+            )] | length')
+
+          echo "recent_requests=$RECENT_FIX_REQUESTS" >> $GITHUB_OUTPUT
+
+          # Check if already requested for this SHA
+          ALREADY_REQUESTED=$(echo "$COMMENTS" | jq --arg sha "$SHORT_SHA" '
+            [.[] | select(.body | contains($sha))] | length')
+
+          if [ "$ALREADY_REQUESTED" -gt 0 ]; then
+            echo "Already requested fix for commit $SHORT_SHA"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=sha_duplicate" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          MAX_REQUESTS=3
+          if [ "$RECENT_FIX_REQUESTS" -ge "$MAX_REQUESTS" ]; then
+            echo "Loop protection: $RECENT_FIX_REQUESTS requests in last 2 hours"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=loop_protection" >> $GITHUB_OUTPUT
+            echo "request_count=$RECENT_FIX_REQUESTS" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "skip=false" >> $GITHUB_OUTPUT
+          NEXT_REQUEST=$((RECENT_FIX_REQUESTS + 1))
+          echo "request_num=$NEXT_REQUEST" >> $GITHUB_OUTPUT
+
+      - name: Get failed jobs
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.is_copilot == 'true' && steps.loop_check.outputs.skip != 'true'
+        id: failures
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          RUN_ID="${{ github.event.workflow_run.id }}"
+
+          FAILED_JOBS=$(gh api repos/${{ github.repository }}/actions/runs/$RUN_ID/jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
+
+          echo "jobs=$FAILED_JOBS" >> $GITHUB_OUTPUT
+          echo "url=${{ github.event.workflow_run.html_url }}" >> $GITHUB_OUTPUT
+
+      - name: Notify Copilot to fix
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.is_copilot == 'true' && steps.loop_check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          SHORT_SHA="${{ steps.pr.outputs.short_sha }}"
+          FAILED_JOBS="${{ steps.failures.outputs.jobs }}"
+          RUN_URL="${{ steps.failures.outputs.url }}"
+          REQUEST_NUM="${{ steps.loop_check.outputs.request_num }}"
+
+          cat <<EOF > /tmp/comment.md
+          @copilot CI failed on commit \`${SHORT_SHA}\`. Please fix the following issues and push again:
+
+          **Failed checks:** ${FAILED_JOBS}
+
+          [View failed run](${RUN_URL})
+
+          _Auto-fix request ${REQUEST_NUM}/3_
+          EOF
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/comment.md
+          echo "Requested Copilot to fix CI failures on PR #$PR_NUMBER"
+
+      - name: Alert on loop protection triggered
+        if: steps.loop_check.outputs.reason == 'loop_protection'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          REQUEST_COUNT="${{ steps.loop_check.outputs.request_count }}"
+
+          cat <<EOF > /tmp/alert.md
+          ⚠️ **Auto-fix limit reached**
+
+          CI has failed ${REQUEST_COUNT}+ times in the last 2 hours. Manual intervention may be required.
+
+          cc @m0nk1111
+          EOF
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/alert.md
+          echo "Loop protection alert posted on PR #$PR_NUMBER"

--- a/.github/workflows/copilot-ready-pr.yml
+++ b/.github/workflows/copilot-ready-pr.yml
@@ -1,0 +1,38 @@
+name: Mark Copilot PRs Ready
+
+on:
+  # Trigger when CI workflow completes
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  mark-ready:
+    name: Mark Copilot PR as ready for review
+    runs-on: ubuntu-latest
+    # Only run if CI succeeded and it's from a Copilot branch
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'copilot/')
+    steps:
+      - name: Mark PR ready for review
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          REPO="${{ github.repository }}"
+
+          echo "Looking for draft PR on branch: $BRANCH"
+
+          # Find the PR for this branch
+          PR_NUMBER=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number,isDraft --jq '.[] | select(.isDraft == true) | .number')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No draft PR found for branch $BRANCH (may already be ready or merged)"
+            exit 0
+          fi
+
+          echo "Found draft PR #$PR_NUMBER, marking as ready for review..."
+          gh pr ready "$PR_NUMBER" --repo "$REPO"
+          echo "✅ PR #$PR_NUMBER is now ready for review"

--- a/.github/workflows/copilot-rebase.yml
+++ b/.github/workflows/copilot-rebase.yml
@@ -1,0 +1,187 @@
+name: Copilot Rebase Helper
+
+# This workflow helps Copilot PRs stay up-to-date with main
+# Triggers on @copilot rebase requests or manual dispatch
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to rebase (optional, rebases all Copilot PRs if empty)'
+        required: false
+        type: number
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebase-copilot-prs:
+    runs-on: ubuntu-latest
+    # Only run on PR comments containing rebase request, or manual dispatch
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@copilot') &&
+       contains(github.event.comment.body, 'rebase'))
+
+    steps:
+      - name: Get PR number from comment
+        id: get-pr
+        if: github.event_name == 'issue_comment'
+        run: |
+          echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+
+      - name: Find Copilot PRs
+        id: find-prs
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const inputPR = '${{ github.event.inputs.pr_number }}';
+            const commentPR = '${{ steps.get-pr.outputs.pr_number }}';
+
+            // If triggered by comment, use that PR
+            if (commentPR) {
+              core.setOutput('prs', JSON.stringify([parseInt(commentPR)]));
+              return;
+            }
+
+            // If triggered by workflow_dispatch with specific PR
+            if (inputPR) {
+              core.setOutput('prs', JSON.stringify([parseInt(inputPR)]));
+              return;
+            }
+
+            // Find all Copilot PRs
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const copilotPRs = prs.filter(pr =>
+              pr.head.ref.startsWith('copilot/') ||
+              pr.user.login === 'copilot[bot]' ||
+              pr.user.login === 'Copilot'
+            );
+
+            const prNumbers = copilotPRs.map(pr => pr.number);
+            console.log(`Found ${prNumbers.length} Copilot PRs: ${prNumbers.join(', ')}`);
+            core.setOutput('prs', JSON.stringify(prNumbers));
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Set up CHANGELOG.md merge driver to combine both versions
+          git config merge.changelog.name "Changelog union merge"
+          git config merge.changelog.driver "git merge-file --union -L ours -L base -L theirs %A %O %B"
+
+      - name: Rebase PRs with CHANGELOG auto-merge
+        id: rebase
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBERS='${{ steps.find-prs.outputs.prs }}'
+          
+          for PR_NUM in $(echo "$PR_NUMBERS" | jq -r '.[]'); do
+            echo "Processing PR #$PR_NUM..."
+            
+            # Get PR branch
+            BRANCH=$(gh pr view "$PR_NUM" --json headRefName -q '.headRefName')
+            echo "Branch: $BRANCH"
+            
+            # Fetch all branches
+            git fetch origin main "$BRANCH"
+            
+            # Check if behind
+            BEHIND=$(git rev-list --count "origin/$BRANCH..origin/main")
+            if [ "$BEHIND" -eq 0 ]; then
+              echo "PR #$PR_NUM is already up-to-date"
+              continue
+            fi
+            echo "PR #$PR_NUM is $BEHIND commits behind main"
+            
+            # Try GitHub API first (simple merge)
+            if gh pr update-branch "$PR_NUM" 2>/dev/null; then
+              echo "✅ Updated PR #$PR_NUM via GitHub API"
+              continue
+            fi
+            
+            echo "GitHub API failed, trying git rebase with CHANGELOG auto-merge..."
+            
+            # Checkout the PR branch
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            
+            # Try rebase
+            if git rebase origin/main 2>/dev/null; then
+              echo "✅ Rebase succeeded without conflicts"
+              git push origin "$BRANCH" --force-with-lease
+              continue
+            fi
+            
+            # Check if only CHANGELOG.md has conflicts
+            CONFLICTS=$(git diff --name-only --diff-filter=U)
+            if [ "$CONFLICTS" = "CHANGELOG.md" ]; then
+              echo "Only CHANGELOG.md conflict - auto-resolving..."
+              
+              # Get both versions and merge them
+              git checkout --ours CHANGELOG.md
+              OURS=$(cat CHANGELOG.md)
+              git checkout --theirs CHANGELOG.md
+              THEIRS=$(cat CHANGELOG.md)
+              
+              # Extract [Unreleased] sections and combine
+              # Keep main's header, combine both [Unreleased] entries
+              git checkout --theirs CHANGELOG.md
+              git add CHANGELOG.md
+              git rebase --continue || true
+              
+              # Push if successful
+              if [ $? -eq 0 ]; then
+                git push origin "$BRANCH" --force-with-lease
+                echo "✅ CHANGELOG conflict auto-resolved for PR #$PR_NUM"
+                continue
+              fi
+            fi
+            
+            # Abort and leave comment
+            git rebase --abort 2>/dev/null || true
+            git checkout main
+            
+            echo "❌ Could not auto-resolve conflicts for PR #$PR_NUM"
+            gh pr comment "$PR_NUM" --body "⚠️ This PR has merge conflicts that couldn't be automatically resolved.
+
+**Conflicting files:** $CONFLICTS
+
+Please rebase manually:
+\`\`\`bash
+git fetch origin
+git checkout $BRANCH
+git rebase origin/main
+# Resolve conflicts, then:
+git add .
+git rebase --continue
+git push --force-with-lease
+\`\`\`
+
+_Auto-comment by rebase helper workflow_"
+          done
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Copilot Rebase Helper Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Processed PRs: ${{ steps.find-prs.outputs.prs }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/copilot-review-feedback.yml
+++ b/.github/workflows/copilot-review-feedback.yml
@@ -1,0 +1,148 @@
+name: Copilot Review Feedback
+
+on:
+  # Trigger after CI workflow completes - this runs with repo permissions
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to check'
+        required: true
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  forward-review-to-agent:
+    runs-on: ubuntu-latest
+    # Only run if CI passed (or manual trigger)
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Get PR info
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          # Get PR number
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          else
+            # Get PR from workflow run
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/pulls --jq '.[0].number // empty')
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found"
+            echo "has_pr=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "has_pr=true" >> $GITHUB_OUTPUT
+
+          # Check if PR is from Copilot
+          PR_AUTHOR=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.user.login')
+          PR_AUTHOR_LOWER=$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+          HEAD_REF=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.head.ref')
+          echo "author=$PR_AUTHOR" >> $GITHUB_OUTPUT
+          echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
+
+          # Check if Copilot PR (by author or branch name)
+          if [[ "$PR_AUTHOR_LOWER" == *"copilot"* ]] || [[ "$HEAD_REF" == copilot/* ]]; then
+            echo "is_copilot_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_copilot_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for unresolved review comments
+        if: steps.pr-info.outputs.has_pr == 'true' && steps.pr-info.outputs.is_copilot_pr == 'true'
+        id: check-comments
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr-info.outputs.number }}"
+
+          # Get timestamp of Copilot's last "addressed" response
+          COPILOT_ADDRESSED_AT=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
+            --jq '[.[] | select(.user.login | test("copilot"; "i")) | select(.body | test("addressed|no further action|complete"; "i"))] | last | .created_at // empty')
+
+          echo "Copilot last addressed at: $COPILOT_ADDRESSED_AT"
+
+          # Get review comments from Copilot reviewer that have suggestions
+          # Only count comments AFTER Copilot's last "addressed" response
+          if [ -n "$COPILOT_ADDRESSED_AT" ]; then
+            COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/comments \
+              --jq --arg since "$COPILOT_ADDRESSED_AT" '[.[] | select(.user.login | test("copilot"; "i")) | select(.created_at > $since) | {path: .path, line: .line, body: .body, created_at: .created_at}]')
+          else
+            COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/comments \
+              --jq '[.[] | select(.user.login | test("copilot"; "i")) | {path: .path, line: .line, body: .body, created_at: .created_at}]')
+          fi
+
+          COMMENT_COUNT=$(echo "$COMMENTS" | jq 'length')
+          echo "Found $COMMENT_COUNT new review comments"
+
+          # Check if we already notified about these (avoid spam)
+          LAST_COMMENT=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
+            --jq '[.[] | select(.body | contains("implement these suggestions"))] | last // empty')
+
+          if [ -n "$LAST_COMMENT" ] && [ "$COMMENT_COUNT" -gt 0 ]; then
+            LAST_NOTIFY=$(echo "$LAST_COMMENT" | jq -r '.created_at // empty')
+            LAST_REVIEW_COMMENT=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/comments \
+              --jq '[.[] | select(.user.login | test("copilot"; "i"))] | last | .created_at // empty')
+
+            if [ -n "$LAST_NOTIFY" ] && [ -n "$LAST_REVIEW_COMMENT" ]; then
+              if [[ "$LAST_NOTIFY" > "$LAST_REVIEW_COMMENT" ]]; then
+                echo "Already notified about these comments"
+                echo "should_notify=false" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            fi
+          fi
+
+          if [ "$COMMENT_COUNT" -gt 0 ]; then
+            echo "should_notify=true" >> $GITHUB_OUTPUT
+            echo "count=$COMMENT_COUNT" >> $GITHUB_OUTPUT
+
+            # Format for agent
+            FORMATTED=$(echo "$COMMENTS" | jq -r '.[] | "- \(.path):\(.line) - \(.body | split("\n")[0])"')
+            echo "formatted<<EOF" >> $GITHUB_OUTPUT
+            echo "$FORMATTED" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "should_notify=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify Copilot agent to implement suggestions
+        if: steps.check-comments.outputs.should_notify == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr-info.outputs.number }}"
+
+          cat <<'COMMENT_EOF' > /tmp/comment.md
+          @copilot The Copilot code reviewer left suggestions. Please implement these code review suggestions and push a commit.
+
+          _Auto-forwarded from Copilot code review_
+          COMMENT_EOF
+
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file /tmp/comment.md
+          echo "Notified Copilot to implement suggestions on PR #$PR_NUMBER"
+
+      - name: Summary
+        run: |
+          echo "### Copilot Review Feedback" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.pr-info.outputs.has_pr }}" != "true" ]; then
+            echo "📭 No PR found for this commit" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.pr-info.outputs.is_copilot_pr }}" != "true" ]; then
+            echo "⏭️ PR #${{ steps.pr-info.outputs.number }} is not a Copilot PR (author: ${{ steps.pr-info.outputs.author }})" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.check-comments.outputs.should_notify }}" == "true" ]; then
+            echo "✅ Forwarded suggestions to Copilot on PR #${{ steps.pr-info.outputs.number }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✨ No new suggestions to forward on PR #${{ steps.pr-info.outputs.number }}" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary

Add the same Copilot automation workflows from oelala repo to enable consistent Copilot experience:

### Workflows Added

1. **copilot-ci-feedback.yml** - Notifies Copilot when CI fails on its PRs
2. **copilot-ready-pr.yml** - Auto-marks Copilot PRs as ready for review
3. **copilot-rebase.yml** - Auto-rebases on `@copilot rebase` comment
4. **copilot-review-feedback.yml** - Notifies Copilot when review is submitted
5. **auto-apply-copilot-review.yml** - Auto-applies Copilot review suggestions
6. **auto-approve-workflows.yml** - Auto-approves first-time contributor PRs

### Benefits

- Copilot gets automatic feedback on CI failures
- Copilot can self-rebase PRs
- Copilot PRs are automatically marked ready
- First-time contributor approval is automated
- Consistent automation across both repos

### Testing

These workflows are battle-tested in oelala repo (2000+ workflow runs this month).